### PR TITLE
First cut at using kotlin-logging instead of println

### DIFF
--- a/azuredata/build.gradle
+++ b/azuredata/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: "$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
+    implementation 'io.github.microutils:kotlin-logging:1.4.9'
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-android
+    implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.21'
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation 'org.amshove.kluent:kluent:1.31'

--- a/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
@@ -34,7 +34,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         super.setUp()
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            ContextProvider.verbose { logger.info { "Attempted to delete test user.  Result: ${response.isSuccessful}" } }
+            logger.debug{ "Attempted to delete test user.  Result: ${response.isSuccessful}" }
 
             user = ensureUser()
         }
@@ -50,7 +50,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            ContextProvider.verbose { logger.info { "Attempted to delete test user.  Result: ${response.isSuccessful}" } }
+            logger.debug { "Attempted to delete test user.  Result: ${response.isSuccessful}" }
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
@@ -8,7 +8,9 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.azure.data.util.ContextProvider
 import junit.framework.Assert.assertEquals
+import mu.KotlinLogging
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Before
@@ -19,6 +21,7 @@ import org.junit.runner.RunWith
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+private val logger = KotlinLogging.logger {}
 
 @RunWith(AndroidJUnit4::class)
 class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, true) {
@@ -31,7 +34,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         super.setUp()
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            ContextProvider.verbose { logger.info { "Attempted to delete test user.  Result: ${response.isSuccessful}" } }
 
             user = ensureUser()
         }
@@ -47,7 +50,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            ContextProvider.verbose { logger.info { "Attempted to delete test user.  Result: ${response.isSuccessful}" } }
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -7,7 +7,6 @@ import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
-import com.azure.data.util.ContextProvider
 import mu.KotlinLogging
 import org.awaitility.Awaitility.await
 import org.junit.After
@@ -26,8 +25,6 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
                                               private val ensureCollection : Boolean = true,
                                               private val ensureDocument : Boolean = false) {
 
-    val verboseLogging = false
-
     val databaseId = "AndroidTest${ResourceType.Database.name}"
     val collectionId = "AndroidTest${ResourceType.Collection.name}"
     val documentId = "AndroidTest${ResourceType.Document.name}"
@@ -44,15 +41,12 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        if (verboseLogging){
-            logger.info("********* Begin Test Setup *********")
-        }
+        logger.debug("********* Begin Test Setup *********")
 
         if (!AzureData.isConfigured) {
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
 
-            
         }
 
         deleteResources()
@@ -69,19 +63,17 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
             ensureDocument()
         }
 
-        if (verboseLogging){
-            logger.info("********* End Test Setup *********")
-        }
+        logger.debug("********* End Test Setup *********")
     }
 
     @After
     open fun tearDown() {
 
-        ContextProvider.verbose { logger.info { "********* Begin Test Tear Down *********"}}
+        logger.debug{ "********* Begin Test Tear Down *********"}
 
         deleteResources()
 
-        ContextProvider.verbose { logger.info { "********* End Test Tear Down *********"}}
+        logger.debug { "********* End Test Tear Down *********"}
     }
 
     fun ensureDatabase() : Database {
@@ -149,7 +141,7 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
         //delete the DB - this should delete all attached resources
 
         AzureData.deleteDatabase(databaseId) { response ->
-            ContextProvider.verbose { logger.info { "Attempted to delete test database.  Result: ${response.isSuccessful}" } }
+            logger.debug{ "Attempted to delete test database.  Result: ${response.isSuccessful}" }
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -7,6 +7,8 @@ import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.azure.data.util.ContextProvider
+import mu.KotlinLogging
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Assert.*
@@ -17,10 +19,14 @@ import org.junit.Before
  * Licensed under the MIT License.
  */
 
+private val logger = KotlinLogging.logger {}
+
 open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
                                               private val ensureDatabase : Boolean = true,
                                               private val ensureCollection : Boolean = true,
                                               private val ensureDocument : Boolean = false) {
+
+    val verboseLogging = false
 
     val databaseId = "AndroidTest${ResourceType.Database.name}"
     val collectionId = "AndroidTest${ResourceType.Collection.name}"
@@ -38,7 +44,9 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        println("********* Begin Test Setup *********")
+        if (verboseLogging){
+            logger.info("********* Begin Test Setup *********")
+        }
 
         if (!AzureData.isConfigured) {
             // Context of the app under test.
@@ -61,17 +69,19 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
             ensureDocument()
         }
 
-        println("********* End Test Setup *********")
+        if (verboseLogging){
+            logger.info("********* End Test Setup *********")
+        }
     }
 
     @After
     open fun tearDown() {
 
-        println("********* Begin Test Tear Down *********")
+        ContextProvider.verbose { logger.info { "********* Begin Test Tear Down *********"}}
 
         deleteResources()
 
-        println("********* End Test Tear Down *********")
+        ContextProvider.verbose { logger.info { "********* End Test Tear Down *********"}}
     }
 
     fun ensureDatabase() : Database {
@@ -139,7 +149,7 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
         //delete the DB - this should delete all attached resources
 
         AzureData.deleteDatabase(databaseId) { response ->
-            println("Attempted to delete test database.  Result: ${response.isSuccessful}")
+            ContextProvider.verbose { logger.info { "Attempted to delete test database.  Result: ${response.isSuccessful}" } }
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
@@ -7,7 +7,6 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
-import com.azure.data.util.ContextProvider
 import junit.framework.Assert.assertEquals
 import mu.KotlinLogging
 import org.awaitility.Awaitility.await
@@ -47,9 +46,7 @@ class UserTests : ResourceTest<User>(ResourceType.User, true, false) {
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(id, databaseId) { response ->
-            ContextProvider.verbose { logger.info {
-                "Attempted to delete test user.  Result: ${response.isSuccessful}"
-            } }
+            logger.debug { "Attempted to delete test user.  Result: ${response.isSuccessful}" }
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
@@ -7,7 +7,9 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.azure.data.util.ContextProvider
 import junit.framework.Assert.assertEquals
+import mu.KotlinLogging
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Assert.assertNotEquals
@@ -19,6 +21,8 @@ import org.junit.runner.RunWith
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+private val logger = KotlinLogging.logger {}
 
 @RunWith(AndroidJUnit4::class)
 class UserTests : ResourceTest<User>(ResourceType.User, true, false) {
@@ -43,7 +47,9 @@ class UserTests : ResourceTest<User>(ResourceType.User, true, false) {
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(id, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            ContextProvider.verbose { logger.info {
+                "Attempted to delete test user.  Result: ${response.isSuccessful}"
+            } }
             deleteResponse = response
         }
 

--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -25,9 +25,9 @@ class AzureData {
         lateinit var documentClient: DocumentClient
 
         @JvmStatic
-        fun configure(context: Context, name: String, key: String, keyType: TokenType = TokenType.MASTER, verboseLogging: Boolean = false) {
+        fun configure(context: Context, name: String, key: String, keyType: TokenType = TokenType.MASTER) {
 
-            ContextProvider.init(context.applicationContext, verboseLogging)
+            ContextProvider.init(context.applicationContext)
 
             baseUri = ResourceUri(name)
             documentClient = DocumentClient(baseUri, key, keyType)
@@ -38,11 +38,6 @@ class AzureData {
         @JvmStatic
         var isConfigured: Boolean = false
             private set
-
-        var verboseLogging: Boolean
-            get() = ContextProvider.verboseLogging
-            set (value) { ContextProvider.verboseLogging = value }
-
 
         //region Databases
 

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -862,7 +862,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
     // query
     private fun <T : Resource> query(query: Query, resourceUri: UrlLink, resourceType: ResourceType, callback: (ResourceListResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose(query)
+        logger.debug{query}
 
         try {
             val json = gson.toJson(query.dictionary)
@@ -1010,14 +1010,14 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
 
     private fun <T : Resource> sendResourceRequest(request: Request, resourceType: ResourceType, resource: T?, callback: (ResourceResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        logger.debug("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
 
         try {
             client.newCall(request)
                     .enqueue(object : Callback {
 
                         override fun onFailure(call: Call, e: IOException) {
-                            logIfVerbose(e)
+                            logger.error("",e)
                             return callback(ResourceResponse(DataError(e), request))
                         }
 
@@ -1026,21 +1026,21 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                                 callback(processResponse(request, response, resourceType, resource, resourceClass))
                     })
         } catch (e: Exception) {
-            logIfVerbose(e)
+            logger.error("",e)
             callback(ResourceResponse(DataError(e), request))
         }
     }
 
     private fun sendRequest(request: Request, callback: (Response) -> Unit) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        logger.debug("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
 
         try {
             client.newCall(request)
                     .enqueue(object : Callback {
 
                         override fun onFailure(call: Call, e: IOException) {
-                            logIfVerbose(e)
+                            logger.error("",e)
                             return callback(Response(DataError(e), request))
                         }
 
@@ -1049,14 +1049,14 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                                 callback(processDataResponse(request, response))
                     })
         } catch (e: Exception) {
-            logIfVerbose(e)
+            logger.error("",e)
             callback(Response(DataError(e), request))
         }
     }
 
     private fun <T : Resource> sendResourceListRequest(request: Request, resourceType: ResourceType, callback: (ResourceListResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        logger.debug("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
 
         try {
             client.newCall(request)
@@ -1071,7 +1071,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                                 callback(processListResponse(request, response, resourceType, resourceClass))
                     })
         } catch (e: Exception) {
-            logIfVerbose(e)
+            logger.error("",e)
             callback(ResourceListResponse(DataError(e), request))
         }
     }
@@ -1083,7 +1083,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                     ?: return ResourceResponse(DataError("Empty response body received"))
             val json = body.string()
 
-            logIfVerbose(json)
+            logger.debug(json)
 
             //check http return code/success
             when {
@@ -1123,7 +1123,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                     ?: return ResourceListResponse(DataError("Empty response body received"), request, response)
             val json = body.string()
 
-            logIfVerbose(json)
+            logger.debug(json)
 
             if (response.isSuccessful) {
 
@@ -1153,7 +1153,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                     ?: return Response(DataError("Empty response body received"), request, response)
             val json = body.string()
 
-            logIfVerbose(json)
+            logger.debug(json)
 
             //check http return code
             return if (response.isSuccessful) {
@@ -1167,16 +1167,6 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
     }
 
     //endregion
-
-    private fun logIfVerbose(thing: Any) {
-
-        ContextProvider.verbose { logger.info { thing } }
-    }
-
-    private fun logIfVerbose(vararg things: Any) {
-
-        ContextProvider.verbose { things.forEach { logger.info { it } } }
-    }
 
     companion object {
 

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -12,6 +12,7 @@ import com.azure.data.model.indexing.IndexingPolicy
 import com.azure.data.util.*
 import com.azure.data.util.json.gson
 import getDefaultHeaders
+import mu.KotlinLogging
 import okhttp3.*
 import java.io.IOException
 
@@ -19,6 +20,8 @@ import java.io.IOException
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+private val logger = KotlinLogging.logger {}
 
 class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: TokenType = TokenType.MASTER) {
 
@@ -907,6 +910,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             return builder.build()
         } catch (e: Exception) {
 
+            logger.error(e.message,e)
             e.printStackTrace()
 
             throw e
@@ -946,7 +950,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             return builder.build()
         } catch (e: Exception) {
 
-            e.printStackTrace()
+            logger.error(e.message,e)
 
             throw e
         }
@@ -971,7 +975,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             return builder.build()
         } catch (e: Exception) {
 
-            e.printStackTrace()
+            logger.error(e.message,e)
 
             throw e
         }
@@ -1166,18 +1170,12 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
 
     private fun logIfVerbose(thing: Any) {
 
-        if (ContextProvider.verboseLogging) {
-            println(thing)
-        }
+        ContextProvider.verbose { logger.info { thing } }
     }
 
     private fun logIfVerbose(vararg things: Any) {
 
-        if (ContextProvider.verboseLogging) {
-            things.forEach {
-                println(it)
-            }
-        }
+        ContextProvider.verbose { things.forEach { logger.info { it } } }
     }
 
     companion object {

--- a/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
@@ -6,6 +6,7 @@ import com.azure.data.constants.TokenType
 import com.azure.data.model.ResourceType
 import com.azure.data.model.Token
 import com.azure.data.util.ContextProvider
+import mu.KotlinLogging
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.*
@@ -14,6 +15,8 @@ import java.util.*
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+private val logger = KotlinLogging.logger {}
 
 class TokenProvider(private var key: String, private var keyType: TokenType = TokenType.MASTER, private var tokenVersion: String = "1.0") {
 
@@ -34,9 +37,7 @@ class TokenProvider(private var key: String, private var keyType: TokenType = To
                 resourceLink,
                 dateString.toLowerCase(Locale.ROOT))
 
-        if (ContextProvider.verboseLogging) {
-            print(payload)
-        }
+        ContextProvider.verbose { logger.info { payload }}
 
         val signature = CryptoProvider.hmacEncrypt(payload, key)
 

--- a/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
@@ -5,7 +5,6 @@ import com.azure.core.http.HttpMethod
 import com.azure.data.constants.TokenType
 import com.azure.data.model.ResourceType
 import com.azure.data.model.Token
-import com.azure.data.util.ContextProvider
 import mu.KotlinLogging
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
@@ -37,7 +36,7 @@ class TokenProvider(private var key: String, private var keyType: TokenType = To
                 resourceLink,
                 dateString.toLowerCase(Locale.ROOT))
 
-        ContextProvider.verbose { logger.info { payload }}
+        logger.debug { payload }
 
         val signature = CryptoProvider.hmacEncrypt(payload, key)
 

--- a/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
@@ -18,5 +18,9 @@ class ContextProvider {
             this.appContext = context
             this.verboseLogging = verboseLogging
         }
+
+        fun verbose( logfun : () -> Unit ) {
+            if (verboseLogging) logfun()
+        }
     }
 }

--- a/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
@@ -12,15 +12,9 @@ class ContextProvider {
     companion object {
 
         lateinit var appContext: Context
-        var verboseLogging: Boolean = false
 
-        fun init(context: Context, verboseLogging: Boolean = false) {
+        fun init(context: Context) {
             this.appContext = context
-            this.verboseLogging = verboseLogging
-        }
-
-        fun verbose( logfun : () -> Unit ) {
-            if (verboseLogging) logfun()
         }
     }
 }

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -14,18 +14,8 @@ import java.util.*
 val gson: Gson =
         GsonBuilder()
                 .disableHtmlEscaping()
-                .checkVerboseMode()
+                .setPrettyPrinting()
                 .registerTypeAdapter(Date::class.java, DateTypeAdapter())
                 .registerTypeAdapter(Timestamp::class.java, TimestampAdapter())
                 .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
                 .create()
-
-
-fun GsonBuilder.checkVerboseMode() : GsonBuilder {
-
-    if (ContextProvider.verboseLogging) {
-        this.setPrettyPrinting()
-    }
-
-    return this
-}


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Partially Fixes #5 and #12 .

Changes Proposed in this pull request:
- use https://github.com/MicroUtils/kotlin-logging as a front end to the Android `Log` class
- Add a `ContextProvider.verbose` method to lazily apply the log if `verboseLogging` is true
- Use the combination in the AzureData library wherever there was a `print()` or `println()`

If this looks good then I'll apply this technique across the rest of the libraries.

Note that the `logger` object is defined separately in each class so that it picks up that classes name as the log message's `tag`.
