### PR TITLE
First cut at using timber instead of println

### DIFF
--- a/azurecore/build.gradle
+++ b/azurecore/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation group: 'com.google.code.gson', name: 'gson', version: "$gsonVersion"
-    implementation 'com.jakewharton.timber:timber:$timberVersion'
+    implementation "com.jakewharton.timber:timber:$timberVersion"
     // https://mvnrepository.com/artifact/commons-codec/commons-codec
     implementation 'commons-codec:commons-codec:1.11'
 }

--- a/azurecore/build.gradle
+++ b/azurecore/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation group: 'com.google.code.gson', name: 'gson', version: "$gsonVersion"
+    implementation 'com.jakewharton.timber:timber:$timberVersion'
     // https://mvnrepository.com/artifact/commons-codec/commons-codec
     implementation 'commons-codec:commons-codec:1.11'
 }

--- a/azurecore/src/main/java/com/azure/core/log/Logger.kt
+++ b/azurecore/src/main/java/com/azure/core/log/Logger.kt
@@ -1,0 +1,52 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.azure.core.log
+
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import android.util.Log
+import timber.log.Timber
+
+inline fun v(message: () -> String)                 = log(Log.VERBOSE) { Timber.v(message()) }
+inline fun v(t: Throwable)                          = log(Log.VERBOSE) {Timber.v(t)}
+inline fun v(t: Throwable, message: () -> String)   = log(Log.VERBOSE) { Timber.v(t, message()) }
+
+inline fun d(message: () -> String)                 = log(Log.DEBUG) { Timber.d(message()) }
+inline fun d(t: Throwable)                          = log(Log.DEBUG) {Timber.d(t)}
+inline fun d(t: Throwable, message: () -> String)   = log(Log.DEBUG) { Timber.d(t, message()) }
+
+inline fun i(message: () -> String)                 = log(Log.DEBUG) { Timber.i(message()) }
+inline fun i(t: Throwable)                          = log(Log.DEBUG) {Timber.i(t)}
+inline fun i(t: Throwable, message: () -> String)   = log(Log.DEBUG) { Timber.i(t, message()) }
+
+inline fun w(message: () -> String)                 = log(Log.WARN) { Timber.w(message()) }
+inline fun w(t: Throwable)                          = log(Log.WARN) {Timber.w(t)}
+inline fun w(t: Throwable, message: () -> String)   = log(Log.WARN) { Timber.w(t, message()) }
+
+inline fun e(message: () -> String)                 = log(Log.ERROR) { Timber.e(message()) }
+inline fun e(t: Throwable)                          = log(Log.ERROR) {Timber.e(t)}
+inline fun e(t: Throwable, message: () -> String)   = log(Log.ERROR) { Timber.e(t, message()) }
+
+inline fun wtf(message: () -> String)               = log(Log.ASSERT) { Timber.wtf(message()) }
+inline fun wtf(t: Throwable)                        = log(Log.ASSERT) {Timber.wtf(t)}
+inline fun wtf(t: Throwable, message: () -> String) = log(Log.ASSERT) { Timber.wtf(t, message()) }
+
+fun startLogging(level: Int){
+    lowestLogLevel = level
+    if (Timber.treeCount()==0) {
+        Timber.plant(Timber.DebugTree())
+    }
+}
+
+/** @suppress */
+@PublishedApi
+internal var lowestLogLevel = Integer.MAX_VALUE
+
+/** @suppress */
+@PublishedApi
+internal inline fun log(level: Int, block: () -> Unit) {
+    if (level>=lowestLogLevel && Timber.treeCount() > 0) block()
+}

--- a/azurecore/src/main/java/com/azure/core/log/Logger.kt
+++ b/azurecore/src/main/java/com/azure/core/log/Logger.kt
@@ -10,6 +10,9 @@ package com.azure.core.log
 import android.util.Log
 import timber.log.Timber
 
+@PublishedApi internal val defaultLogLevel = Log.ASSERT
+@PublishedApi internal val defaultLogTree  = Timber.DebugTree()
+
 inline fun v(message: () -> String)                 = log(Log.VERBOSE) { Timber.v(message()) }
 inline fun v(t: Throwable)                          = log(Log.VERBOSE) {Timber.v(t)}
 inline fun v(t: Throwable, message: () -> String)   = log(Log.VERBOSE) { Timber.v(t, message()) }
@@ -37,7 +40,14 @@ inline fun wtf(t: Throwable, message: () -> String) = log(Log.ASSERT) { Timber.w
 /**
  * Start logging at the specified log level. Can be called more than once to change log level
  */
-fun startLogging(level: Int = Log.VERBOSE){
+fun startLogging(level: Int = Log.VERBOSE, tree : Timber.Tree? = null){
+    if (tree!=null) {
+        Timber.plant(tree)
+    } else {
+        if (Timber.treeCount()==0) {
+            Timber.plant(defaultLogTree)
+        }
+    }
     logLevel = level
 }
 
@@ -45,20 +55,14 @@ fun startLogging(level: Int = Log.VERBOSE){
  * Stop logging.
  */
 fun stopLogging(){
-    logLevel = Integer.MAX_VALUE
+    Timber.uprootAll()
+    logLevel = defaultLogLevel
 }
 
 /**
  * The current log level. Logs at this level or higher will be sent to the system log
  */
-var logLevel = Log.ASSERT
-    get() = field
-    set(value) {
-        field = value
-        if (Timber.treeCount()==0) {
-            Timber.plant(Timber.DebugTree())
-        }
-    }
+var logLevel = defaultLogLevel
 
 /** @suppress */
 @PublishedApi

--- a/azurecore/src/main/java/com/azure/core/log/Logger.kt
+++ b/azurecore/src/main/java/com/azure/core/log/Logger.kt
@@ -34,19 +34,34 @@ inline fun wtf(message: () -> String)               = log(Log.ASSERT) { Timber.w
 inline fun wtf(t: Throwable)                        = log(Log.ASSERT) {Timber.wtf(t)}
 inline fun wtf(t: Throwable, message: () -> String) = log(Log.ASSERT) { Timber.wtf(t, message()) }
 
-fun startLogging(level: Int){
-    lowestLogLevel = level
-    if (Timber.treeCount()==0) {
-        Timber.plant(Timber.DebugTree())
-    }
+/**
+ * Start logging at the specified log level. Can be called more than once to change log level
+ */
+fun startLogging(level: Int = Log.VERBOSE){
+    logLevel = level
 }
 
-/** @suppress */
-@PublishedApi
-internal var lowestLogLevel = Integer.MAX_VALUE
+/**
+ * Stop logging.
+ */
+fun stopLogging(){
+    logLevel = Integer.MAX_VALUE
+}
+
+/**
+ * The current log level. Logs at this level or higher will be sent to the system log
+ */
+var logLevel = Log.ASSERT
+    get() = field
+    set(value) {
+        field = value
+        if (Timber.treeCount()==0) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
 
 /** @suppress */
 @PublishedApi
 internal inline fun log(level: Int, block: () -> Unit) {
-    if (level>=lowestLogLevel && Timber.treeCount() > 0) block()
+    if (level>=logLevel && Timber.treeCount() > 0) block()
 }

--- a/azurecore/src/main/java/com/azure/core/log/Logger.kt
+++ b/azurecore/src/main/java/com/azure/core/log/Logger.kt
@@ -10,7 +10,7 @@ package com.azure.core.log
 import android.util.Log
 import timber.log.Timber
 
-@PublishedApi internal val defaultLogLevel = Log.ASSERT
+@PublishedApi internal val defaultLogLevel = Log.VERBOSE
 @PublishedApi internal val defaultLogTree  = Timber.DebugTree()
 
 inline fun v(message: () -> String)                 = log(Log.VERBOSE) { Timber.v(message()) }
@@ -38,31 +38,46 @@ inline fun wtf(t: Throwable)                        = log(Log.ASSERT) {Timber.wt
 inline fun wtf(t: Throwable, message: () -> String) = log(Log.ASSERT) { Timber.wtf(t, message()) }
 
 /**
- * Start logging at the specified log level. Can be called more than once to change log level
+ * Start logging at the current log level
  */
-fun startLogging(level: Int = Log.VERBOSE, tree : Timber.Tree? = null){
-    if (tree!=null) {
-        Timber.plant(tree)
-    } else {
-        if (Timber.treeCount()==0) {
-            Timber.plant(defaultLogTree)
-        }
+fun startLogging(){
+    if (Timber.treeCount()==0){
+        Timber.plant(defaultLogTree)
     }
+}
+
+/**
+ * Start logging at this new log level.
+ */
+fun startLogging(level: Int = defaultLogLevel){
     logLevel = level
+    startLogging()
 }
 
 /**
  * Stop logging.
  */
 fun stopLogging(){
-    Timber.uprootAll()
     logLevel = defaultLogLevel
+    if (Timber.forest().contains(defaultLogTree)) {
+        Timber.uproot(defaultLogTree)
+    }
 }
 
 /**
  * The current log level. Logs at this level or higher will be sent to the system log
  */
 var logLevel = defaultLogLevel
+
+/** @suppress */
+fun startLogging(tree : Timber.Tree){
+    Timber.plant(tree)
+}
+
+/** @suppress */
+fun stopLogging(tree : Timber.Tree){
+    Timber.uproot(tree)
+}
 
 /** @suppress */
 @PublishedApi

--- a/azurecore/src/test/java/com/azure/core/LogTest.kt
+++ b/azurecore/src/test/java/com/azure/core/LogTest.kt
@@ -45,12 +45,12 @@ class LogTest {
 
     @Before
     fun before() {
-        startLogging(Log.VERBOSE,tree)
+        startLogging(tree)
     }
 
     @After
     fun after() {
-        stopLogging()
+        stopLogging(tree)
     }
 
     @Test @Throws(Exception::class) fun can_log_each_level() {

--- a/azurecore/src/test/java/com/azure/core/LogTest.kt
+++ b/azurecore/src/test/java/com/azure/core/LogTest.kt
@@ -1,0 +1,88 @@
+package com.azure.core
+
+import android.util.Log
+import com.azure.core.log.*
+import org.junit.After
+import org.junit.Test
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import timber.log.Timber
+
+class LogTest {
+
+    enum class Lev {
+        ZERO_IS_NOT_A_LEVEL,
+        ONE_IS_NOT_A_LEVEL,
+        verbose,
+        debug,
+        info,
+        warn,
+        error,
+        assert,
+    }
+
+    class ArrayTree : Timber.Tree() {
+        data class Entry( val priority: Int, val tag: String?, val message: String, val throwable: Throwable?)
+        val log = ArrayList<Entry>()
+        override fun log(priority: Int, tag: String?, message: String, throwable: Throwable?) {
+            log.add(Entry(priority,tag,message,throwable))
+        }
+        fun clear() : ArrayTree {
+            log.clear()
+            return this
+        }
+        fun assert(index: Int, priority: Int, tag: String?, message: String, throwable: Throwable?) {
+            assertEquals(true,index<log.size)
+            assertEquals(priority, log[index].priority)
+            assertEquals(tag, log[index].tag)
+            assertEquals(message, log[index].message)
+            assertEquals(throwable, log[index].throwable)
+        }
+    }
+
+    private val tree = ArrayTree()
+
+    @Before
+    fun before() {
+        startLogging(Log.VERBOSE,tree)
+    }
+
+    @After
+    fun after() {
+        stopLogging()
+    }
+
+    @Test @Throws(Exception::class) fun can_log_each_level() {
+        var index = 0
+        tree.clear()
+        assertEquals(0, tree.log.size)
+        v{Lev.verbose.name}
+        tree.assert(index++,Log.VERBOSE,null,Lev.verbose.name,null)
+        d{Lev.debug.name}
+        tree.assert(index++,Log.DEBUG,null,Lev.debug.name,null)
+        i{Lev.info.name}
+        tree.assert(index++,Log.INFO,null,Lev.info.name,null)
+        w{Lev.warn.name}
+        tree.assert(index++,Log.WARN,null,Lev.warn.name,null)
+        e{Lev.error.name}
+        tree.assert(index++,Log.ERROR,null,Lev.error.name,null)
+    }
+
+    @Test @Throws(Exception::class) fun can_change_levels() {
+        var index = 0
+        tree.clear()
+        startLogging(Log.WARN)
+        assertEquals(0, tree.log.size)
+        v{Lev.verbose.name}
+        assertEquals(0, tree.log.size)
+        d{Lev.debug.name}
+        assertEquals(0, tree.log.size)
+        i{Lev.info.name}
+        assertEquals(0, tree.log.size)
+        w{Lev.warn.name}
+        tree.assert(index++,Log.WARN,null,Lev.warn.name,null)
+        e{Lev.error.name}
+        tree.assert(index++,Log.ERROR,null,Lev.error.name,null)
+    }
+}

--- a/azuredata/build.gradle
+++ b/azuredata/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: "$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
+    implementation "com.github.ajalt:timberkt:$timberKtVersion"
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation 'org.amshove.kluent:kluent:1.31'

--- a/azuredata/build.gradle
+++ b/azuredata/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: "$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
-    implementation "com.github.ajalt:timberkt:$timberKtVersion"
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation 'org.amshove.kluent:kluent:1.31'
@@ -41,7 +40,8 @@ dependencies {
     androidTestImplementation "com.android.support.test:rules:$testRulesVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
-    debugImplementation project(':azurecore')
+    // https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#variant_dependencies
+    implementation project(':azurecore')
     // release implementation will be released via jCenter/maven/etc.
 }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
@@ -8,6 +8,7 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.github.ajalt.timberkt.d
 import junit.framework.Assert.assertEquals
 import org.awaitility.Awaitility.await
 import org.junit.After
@@ -31,7 +32,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         super.setUp()
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            d{"Attempted to delete test user.  Result: ${response.isSuccessful}"}
 
             user = ensureUser()
         }
@@ -47,7 +48,7 @@ class PermissionTests : ResourceTest<Permission>(ResourceType.Permission, true, 
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(userId, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            d{"Attempted to delete test user.  Result: ${response.isSuccessful}"}
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/PermissionTests.kt
@@ -1,6 +1,7 @@
 package com.azure.data.integration
 
 import android.support.test.runner.AndroidJUnit4
+import com.azure.core.log.d
 import com.azure.data.*
 import com.azure.data.model.DocumentCollection
 import com.azure.data.model.Permission
@@ -8,7 +9,6 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
-import com.github.ajalt.timberkt.d
 import junit.framework.Assert.assertEquals
 import org.awaitility.Awaitility.await
 import org.junit.After

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.azure.core.log.d
 import com.azure.core.log.startLogging
 import com.azure.data.AzureData
+import com.azure.data.constants.TokenType
 import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -7,6 +7,9 @@ import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.github.ajalt.timberkt.Timber
+import com.github.ajalt.timberkt.Timber.DebugTree
+import com.github.ajalt.timberkt.d
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Assert.*
@@ -38,14 +41,17 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        println("********* Begin Test Setup *********")
+        println("********* Pre Configuration *********")
 
         if (!AzureData.isConfigured) {
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
 
-            
+            Timber.plant(DebugTree())
+
         }
+
+        d{"********* Begin Test Setup *********"}
 
         deleteResources()
 
@@ -61,17 +67,17 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
             ensureDocument()
         }
 
-        println("********* End Test Setup *********")
+        d{"********* End Test Setup *********"}
     }
 
     @After
     open fun tearDown() {
 
-        println("********* Begin Test Tear Down *********")
+        d{"********* Begin Test Tear Down *********"}
 
         deleteResources()
 
-        println("********* End Test Tear Down *********")
+        d{"********* End Test Tear Down *********"}
     }
 
     fun ensureDatabase() : Database {
@@ -139,7 +145,7 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
         //delete the DB - this should delete all attached resources
 
         AzureData.deleteDatabase(databaseId) { response ->
-            println("Attempted to delete test database.  Result: ${response.isSuccessful}")
+            d{"Attempted to delete test database.  Result: ${response.isSuccessful}"}
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -2,9 +2,9 @@ package com.azure.data.integration
 
 import android.support.test.InstrumentationRegistry
 import android.util.Log
-import com.azure.core.log.*
+import com.azure.core.log.d
+import com.azure.core.log.startLogging
 import com.azure.data.AzureData
-import com.azure.data.constants.TokenType
 import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse
@@ -40,20 +40,15 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        startLogging(Log.WARN)
-        v{"verbose"}
-        d{"debug"}
-        w{"warn"}
-        e{"error"}
-        d{"********* Pre Configuration *********"}
+        startLogging(Log.VERBOSE)
+
+        d{"********* Begin Test Setup *********"}
 
         if (!AzureData.isConfigured) {
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
 
         }
-
-        d{"********* Begin Test Setup *********"}
 
         deleteResources()
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -1,15 +1,14 @@
 package com.azure.data.integration
 
 import android.support.test.InstrumentationRegistry
+import android.util.Log
+import com.azure.core.log.*
 import com.azure.data.AzureData
 import com.azure.data.constants.TokenType
 import com.azure.data.model.*
 import com.azure.data.service.ResourceListResponse
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
-import com.github.ajalt.timberkt.Timber
-import com.github.ajalt.timberkt.Timber.DebugTree
-import com.github.ajalt.timberkt.d
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Assert.*
@@ -41,13 +40,17 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        println("********* Pre Configuration *********")
+        startLogging(Log.ERROR)
+        v{"verbose"}
+        d{"debug"}
+        w{"warn"}
+        e{"error"}
+        d{"********* Pre Configuration *********"}
 
         if (!AzureData.isConfigured) {
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
 
-            Timber.plant(DebugTree())
 
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -40,7 +40,7 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
     @Before
     open fun setUp() {
 
-        startLogging(Log.ERROR)
+        startLogging(Log.WARN)
         v{"verbose"}
         d{"debug"}
         w{"warn"}
@@ -50,7 +50,6 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
         if (!AzureData.isConfigured) {
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
-
 
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
@@ -7,6 +7,7 @@ import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
+import com.github.ajalt.timberkt.d
 import junit.framework.Assert.assertEquals
 import org.awaitility.Awaitility.await
 import org.junit.After
@@ -43,7 +44,7 @@ class UserTests : ResourceTest<User>(ResourceType.User, true, false) {
         var deleteResponse: Response? = null
 
         AzureData.deleteUser(id, databaseId) { response ->
-            println("Attempted to delete test user.  Result: ${response.isSuccessful}")
+            d{"Attempted to delete test user.  Result: ${response.isSuccessful}"}
             deleteResponse = response
         }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/UserTests.kt
@@ -1,13 +1,13 @@
 package com.azure.data.integration
 
 import android.support.test.runner.AndroidJUnit4
+import com.azure.core.log.d
 import com.azure.data.*
 import com.azure.data.model.Database
 import com.azure.data.model.ResourceType
 import com.azure.data.model.User
 import com.azure.data.service.ResourceResponse
 import com.azure.data.service.Response
-import com.github.ajalt.timberkt.d
 import junit.framework.Assert.assertEquals
 import org.awaitility.Awaitility.await
 import org.junit.After

--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -25,9 +25,9 @@ class AzureData {
         lateinit var documentClient: DocumentClient
 
         @JvmStatic
-        fun configure(context: Context, name: String, key: String, keyType: TokenType = TokenType.MASTER, verboseLogging: Boolean = false) {
+        fun configure(context: Context, name: String, key: String, keyType: TokenType = TokenType.MASTER) {
 
-            ContextProvider.init(context.applicationContext, verboseLogging)
+            ContextProvider.init(context.applicationContext)
 
             baseUri = ResourceUri(name)
             documentClient = DocumentClient(baseUri, key, keyType)
@@ -38,11 +38,6 @@ class AzureData {
         @JvmStatic
         var isConfigured: Boolean = false
             private set
-
-        var verboseLogging: Boolean
-            get() = ContextProvider.verboseLogging
-            set (value) { ContextProvider.verboseLogging = value }
-
 
         //region Databases
 

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -11,6 +11,8 @@ import com.google.gson.reflect.TypeToken
 import com.azure.data.model.indexing.IndexingPolicy
 import com.azure.data.util.*
 import com.azure.data.util.json.gson
+import com.github.ajalt.timberkt.d
+import com.github.ajalt.timberkt.e
 import getDefaultHeaders
 import okhttp3.*
 import java.io.IOException
@@ -859,7 +861,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
     // query
     private fun <T : Resource> query(query: Query, resourceUri: UrlLink, resourceType: ResourceType, callback: (ResourceListResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose(query)
+        d{query.toString()}
 
         try {
             val json = gson.toJson(query.dictionary)
@@ -905,11 +907,11 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             }
 
             return builder.build()
-        } catch (e: Exception) {
+        } catch (ex: Exception) {
 
-            e.printStackTrace()
+            e(ex)
 
-            throw e
+            throw ex
         }
     }
 
@@ -944,11 +946,11 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             }
 
             return builder.build()
-        } catch (e: Exception) {
+        } catch (ex: Exception) {
 
-            e.printStackTrace()
+            e(ex)
 
-            throw e
+            throw ex
         }
     }
 
@@ -969,11 +971,11 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
             }
 
             return builder.build()
-        } catch (e: Exception) {
+        } catch (ex: Exception) {
 
-            e.printStackTrace()
+            e(ex)
 
-            throw e
+            throw ex
         }
     }
 
@@ -1006,53 +1008,62 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
 
     private fun <T : Resource> sendResourceRequest(request: Request, resourceType: ResourceType, resource: T?, callback: (ResourceResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        d{"***"}
+        d{"Sending ${request.method()} request for Data to ${request.url()}"}
+        d{"\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}"}
+        d{"***"}
 
         try {
             client.newCall(request)
                     .enqueue(object : Callback {
 
-                        override fun onFailure(call: Call, e: IOException) {
-                            logIfVerbose(e)
-                            return callback(ResourceResponse(DataError(e), request))
+                        override fun onFailure(call: Call, ex: IOException) {
+                            e(ex)
+                            return callback(ResourceResponse(DataError(ex), request))
                         }
 
                         @Throws(IOException::class)
                         override fun onResponse(call: Call, response: okhttp3.Response) =
                                 callback(processResponse(request, response, resourceType, resource, resourceClass))
                     })
-        } catch (e: Exception) {
-            logIfVerbose(e)
-            callback(ResourceResponse(DataError(e), request))
+        } catch (ex: Exception) {
+            e(ex)
+            callback(ResourceResponse(DataError(ex), request))
         }
     }
 
     private fun sendRequest(request: Request, callback: (Response) -> Unit) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        d{"***"}
+        d{"Sending ${request.method()} request for Data to ${request.url()}"}
+        d{"\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}"}
+        d{"***"}
 
         try {
             client.newCall(request)
                     .enqueue(object : Callback {
 
-                        override fun onFailure(call: Call, e: IOException) {
-                            logIfVerbose(e)
-                            return callback(Response(DataError(e), request))
+                        override fun onFailure(call: Call, ex: IOException) {
+                            e(ex)
+                            return callback(Response(DataError(ex), request))
                         }
 
                         @Throws(IOException::class)
                         override fun onResponse(call: Call, response: okhttp3.Response) =
                                 callback(processDataResponse(request, response))
                     })
-        } catch (e: Exception) {
-            logIfVerbose(e)
-            callback(Response(DataError(e), request))
+        } catch (ex: Exception) {
+            e(ex)
+            callback(Response(DataError(ex), request))
         }
     }
 
     private fun <T : Resource> sendResourceListRequest(request: Request, resourceType: ResourceType, callback: (ResourceListResponse<T>) -> Unit, resourceClass: Class<T>? = null) {
 
-        logIfVerbose("***", "Sending ${request.method()} request for Data to ${request.url()}", "\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}", "***")
+        d{"***"}
+        d{"Sending ${request.method()} request for Data to ${request.url()}"}
+        d{"\tContent : length = ${request.body()?.contentLength()}, type = ${request.body()?.contentType()}"}
+        d{"***"}
 
         try {
             client.newCall(request)
@@ -1066,9 +1077,9 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
                         override fun onResponse(call: Call, response: okhttp3.Response) =
                                 callback(processListResponse(request, response, resourceType, resourceClass))
                     })
-        } catch (e: Exception) {
-            logIfVerbose(e)
-            callback(ResourceListResponse(DataError(e), request))
+        } catch (ex: Exception) {
+            e(ex)
+            callback(ResourceListResponse(DataError(ex), request))
         }
     }
 
@@ -1077,9 +1088,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
         try {
             val body = response.body()
                     ?: return ResourceResponse(DataError("Empty response body received"))
-            val json = body.string()
-
-            logIfVerbose(json)
+            val json = body.string().also{d{it}}
 
             //check http return code/success
             when {
@@ -1117,9 +1126,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
         try {
             val body = response.body()
                     ?: return ResourceListResponse(DataError("Empty response body received"), request, response)
-            val json = body.string()
-
-            logIfVerbose(json)
+            val json = body.string().also{d{it}}
 
             if (response.isSuccessful) {
 
@@ -1147,9 +1154,7 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
         try {
             val body = response.body()
                     ?: return Response(DataError("Empty response body received"), request, response)
-            val json = body.string()
-
-            logIfVerbose(json)
+            val json = body.string().also{d{it}}
 
             //check http return code
             return if (response.isSuccessful) {
@@ -1163,22 +1168,6 @@ class DocumentClient(private val baseUri: ResourceUri, key: String, keyType: Tok
     }
 
     //endregion
-
-    private fun logIfVerbose(thing: Any) {
-
-        if (ContextProvider.verboseLogging) {
-            println(thing)
-        }
-    }
-
-    private fun logIfVerbose(vararg things: Any) {
-
-        if (ContextProvider.verboseLogging) {
-            things.forEach {
-                println(it)
-            }
-        }
-    }
 
     companion object {
 

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -3,6 +3,8 @@ package com.azure.data.service
 import com.azure.core.http.HttpMediaType
 import com.azure.core.http.HttpMethod
 import com.azure.core.http.HttpStatusCode
+import com.azure.core.log.d
+import com.azure.core.log.e
 import com.azure.data.constants.TokenType
 import com.azure.data.constants.HttpHeaderValue
 import com.azure.data.constants.MSHttpHeader
@@ -11,8 +13,6 @@ import com.google.gson.reflect.TypeToken
 import com.azure.data.model.indexing.IndexingPolicy
 import com.azure.data.util.*
 import com.azure.data.util.json.gson
-import com.github.ajalt.timberkt.d
-import com.github.ajalt.timberkt.e
 import getDefaultHeaders
 import okhttp3.*
 import java.io.IOException

--- a/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
@@ -6,6 +6,7 @@ import com.azure.data.constants.TokenType
 import com.azure.data.model.ResourceType
 import com.azure.data.model.Token
 import com.azure.data.util.ContextProvider
+import com.github.ajalt.timberkt.d
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.*
@@ -33,10 +34,7 @@ class TokenProvider(private var key: String, private var keyType: TokenType = To
                 resourceType.path.toLowerCase(Locale.ROOT),
                 resourceLink,
                 dateString.toLowerCase(Locale.ROOT))
-
-        if (ContextProvider.verboseLogging) {
-            print(payload)
-        }
+                .also { d{it} }
 
         val signature = CryptoProvider.hmacEncrypt(payload, key)
 

--- a/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/service/TokenProvider.kt
@@ -2,11 +2,10 @@ package com.azure.data.service
 
 import com.azure.core.crypto.CryptoProvider
 import com.azure.core.http.HttpMethod
+import com.azure.core.log.d
 import com.azure.data.constants.TokenType
 import com.azure.data.model.ResourceType
 import com.azure.data.model.Token
-import com.azure.data.util.ContextProvider
-import com.github.ajalt.timberkt.d
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.*

--- a/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
+++ b/azuredata/src/main/java/com/azure/data/util/ContextProvider.kt
@@ -12,11 +12,9 @@ class ContextProvider {
     companion object {
 
         lateinit var appContext: Context
-        var verboseLogging: Boolean = false
 
-        fun init(context: Context, verboseLogging: Boolean = false) {
+        fun init(context: Context) {
             this.appContext = context
-            this.verboseLogging = verboseLogging
         }
     }
 }

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -1,9 +1,10 @@
 package com.azure.data.util.json
 
+import android.util.Log
+import com.azure.core.log.logLevel
 import com.azure.core.util.DateTypeAdapter
 import com.google.gson.*
 import com.azure.data.model.*
-import com.azure.data.util.ContextProvider
 import java.util.*
 
 /**
@@ -14,8 +15,15 @@ import java.util.*
 val gson: Gson =
         GsonBuilder()
                 .disableHtmlEscaping()
-                .setPrettyPrinting()
+                .checkVerboseMode()
                 .registerTypeAdapter(Date::class.java, DateTypeAdapter())
                 .registerTypeAdapter(Timestamp::class.java, TimestampAdapter())
                 .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
                 .create()
+
+fun GsonBuilder.checkVerboseMode() : GsonBuilder {
+    if (logLevel <= Log.DEBUG) {
+        this.setPrettyPrinting()
+    }
+    return this
+}

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -22,8 +22,10 @@ val gson: Gson =
                 .create()
 
 fun GsonBuilder.checkVerboseMode() : GsonBuilder {
+
     if (logLevel <= Log.DEBUG) {
         this.setPrettyPrinting()
     }
+
     return this
 }

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -14,18 +14,8 @@ import java.util.*
 val gson: Gson =
         GsonBuilder()
                 .disableHtmlEscaping()
-                .checkVerboseMode()
+                .setPrettyPrinting()
                 .registerTypeAdapter(Date::class.java, DateTypeAdapter())
                 .registerTypeAdapter(Timestamp::class.java, TimestampAdapter())
                 .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
                 .create()
-
-
-fun GsonBuilder.checkVerboseMode() : GsonBuilder {
-
-    if (ContextProvider.verboseLogging) {
-        this.setPrettyPrinting()
-    }
-
-    return this
-}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://jitpack.io" }
         maven {
             url "https://maven.google.com"
         }
@@ -35,7 +34,7 @@ allprojects {
         espressoVersion = "3.0.1"
         testRunnerVersion = "1.0.1"
         testRulesVersion = "1.0.1"
-        timberKtVersion = "1.4.0"
+        timberVersion = "4.7.0"
         awaitilityVersion = "3.0.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
         maven {
             url "https://maven.google.com"
         }
@@ -34,6 +35,7 @@ allprojects {
         espressoVersion = "3.0.1"
         testRunnerVersion = "1.0.1"
         testRulesVersion = "1.0.1"
+        timberKtVersion = "1.4.0"
         awaitilityVersion = "3.0.0"
     }
 }


### PR DESCRIPTION
Partially Fixes #5 and #12 .

Changes Proposed in this pull request:

- remove `verboseLogging` from AzureData. Instead use the facilities provided by the logging library.
- use [timberkt](https://github.com/ajalt/timberkt) as a front end to the Android Log class. timberkt is a front end to the [Timber](https://github.com/JakeWharton/timber)  library.
- Use timberkt wherever there is a print() or println()
