### PR TITLE
Dont accidently post your master key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ freeline.py
 freeline/
 freeline_project_description.json
 
+# Sensitive information storage files
+azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
+
 
 Data/.idea/dictionaries/nater.xml
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,6 @@ freeline.py
 freeline/
 freeline_project_description.json
 
-# Sensitive information storage files
-azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
-
 
 Data/.idea/dictionaries/nater.xml
 .DS_Store

--- a/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
@@ -1,0 +1,9 @@
+package com.azure.data.integration
+
+/*
+This file contains keys and database ids that should not be pushed to the git repository
+The file is included in .gitignore, so any changes to it will not be saved to the repository.
+ */
+
+val azureCosmosDbAccount  = "" // Usually matches "database2<12MoreLowerCaseCharacters>"
+val azureCosmosPrimaryKey = "" // Matches "<86CharsOfUpperAndLowerCaseWithNumbers>=="

--- a/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
@@ -7,6 +7,9 @@ command to ensure that any changes to this file will be ignored by git:
 
 git update-index --assume-unchanged azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
 
+if you need to undo this change, execute the following command:
+
+git update-index --no-assume-unchanged azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
  */
 
 val azureCosmosDbAccount  = "" // Usually matches "database2<12MoreLowerCaseCharacters>"

--- a/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
@@ -1,8 +1,12 @@
 package com.azure.data.integration
 
 /*
-This file contains keys and database ids that should not be pushed to the git repository
-The file is included in .gitignore, so any changes to it will not be saved to the repository.
+This file contains keys and database ids that MUST not be pushed to the git repository
+Once you've downloaded the repository to your local machine, execute  following git
+command to ensure that any changes to this file will be ignored by git:
+
+git update-index --assume-unchanged azuredata/src/androidTest/java/com/azure/data/integration/DoNotDistribute.kt
+
  */
 
 val azureCosmosDbAccount  = "" // Usually matches "database2<12MoreLowerCaseCharacters>"

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -48,6 +48,11 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
             // Context of the app under test.
             val appContext = InstrumentationRegistry.getTargetContext()
 
+            AzureData.configure(
+                    appContext,
+                    azureCosmosDbAccount,
+                    azureCosmosPrimaryKey,
+                    PermissionMode.All)
 
         }
 


### PR DESCRIPTION
Changes Proposed in this pull request:
- Move database name and key into their own file that can be ignored with `git update-index --assume-unchanged`

