### PR TITLE
Add a custom deserializer for ResourceList

### DIFF
--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -15,6 +15,7 @@ import com.azure.data.constants.MSHttpHeader
 import com.azure.data.model.*
 import com.azure.data.model.indexing.IndexingPolicy
 import com.azure.data.util.*
+import com.azure.data.util.json.ResourceListJsonDeserializer
 import com.azure.data.util.json.gson
 import com.google.gson.reflect.TypeToken
 import getDefaultHeaders
@@ -1249,9 +1250,7 @@ class DocumentClient private constructor() {
 
                 //TODO: see if there's any benefit to caching these type tokens performance wise (or for any other reason)
                 val type = resourceType ?: resourceLocation.resourceType.type
-                val listType = TypeToken.getParameterized(ResourceList::class.java, type).type
-                val resourceList = gson.fromJson<ResourceList<T>>(json, listType)
-                        ?: return ListResponse(json.toError(), request, response, json)
+                val resourceList = ResourceListJsonDeserializer<T>().deserialize(json, type)
 
                 setResourceMetadata(response, resourceList, resourceLocation.resourceType)
 

--- a/azuredata/src/main/java/com/azure/data/service/ResourceCache.kt
+++ b/azuredata/src/main/java/com/azure/data/service/ResourceCache.kt
@@ -41,8 +41,8 @@ internal class ResourceCache private constructor() {
         ResourceOracle.shared.storeLinks(resource)
 
         if (isEnabled) {
-            safeExecute {
-                executor.execute {
+            executor.execute {
+                safeExecute {
                     ContextProvider.appContext.resourceCacheFile(resource)?.let {
                         it.bufferedWriter().use {
                             it.write(encrypt(gson.toJson(resource)))

--- a/azuredata/src/main/java/com/azure/data/util/json/ResourceListDeserializer.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/ResourceListDeserializer.kt
@@ -1,0 +1,28 @@
+package com.azure.data.util.json
+
+import com.azure.data.model.*
+import com.google.gson.JsonParser
+import java.lang.reflect.Type
+
+internal class ResourceListJsonDeserializer<T: Resource> {
+
+    fun deserialize(json: String, resourceType: Type): ResourceList<T> {
+        val resourceList = ResourceList<T>()
+        var jsonObject = JsonParser().parse(json).asJsonObject
+
+        jsonObject.keySet().forEach {
+            when (it) {
+                ResourceList.Companion.Keys.countKey -> resourceList.count = jsonObject.get(it).asInt
+                ResourceBase.resourceIdKey -> resourceList.resourceId = jsonObject.get(it).asString
+
+                else -> {
+                    resourceList.items = jsonObject.get(it).asJsonArray.map {
+                        gson.fromJson<T>(it, resourceType)
+                    }
+                }
+            }
+        }
+
+        return resourceList
+    }
+}

--- a/azuredata/src/main/java/com/azure/data/util/json/ResourceWriteOperationAdapter.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/ResourceWriteOperationAdapter.kt
@@ -33,7 +33,7 @@ internal class ResourceWriteOperationAdapter: JsonSerializer<ResourceWriteOperat
     override fun deserialize(json: JsonElement?, typeOfT: Type?, context: JsonDeserializationContext?): ResourceWriteOperation? {
         json?.asJsonObject?.let {
             val type = it.getAsJsonPrimitive("type").asString
-            val resource = deserializeResource(it.get("resource"))
+            val resource = it.get("resource")?.let { deserializeResource(it) }
             val location = deserializeLocation(it.getAsJsonObject("location"))
             val path = it.getAsJsonPrimitive("path").asString
             val headers = deserializeHeaders(it.getAsJsonObject("headers"))
@@ -41,7 +41,7 @@ internal class ResourceWriteOperationAdapter: JsonSerializer<ResourceWriteOperat
 
             return ResourceWriteOperation(
                 type = ResourceWriteOperationType.valueOf(type),
-                resource = resource as Resource,
+                resource = resource,
                 resourceLocation = location,
                 resourceLocalContentPath = path,
                 httpHeaders = headers


### PR DESCRIPTION
Fixes #48.

This PR fixes an issue with the deserialization of `ResourceList<T>` when a custom type adapter has been registered with `Gson` for `T`. When `T` has a custom type adapter, the type adapter is not used during the deserialization of `ResourceList<T>`.

This PR fixes it by "manually" deserializing objects of type `ResourceList<T>` by first converting the JSON into `JsonElement`s and then reconstructing the objects from the JSON nodes.
