### PR TITLE
Fix example apps and expose GsonBuilder during configuration

### DIFF
--- a/Example/AzureDataAndroidExample/app/build.gradle
+++ b/Example/AzureDataAndroidExample/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     compileOptions {
         sourceCompatibility 1.8
@@ -34,7 +34,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
@@ -44,5 +44,5 @@ dependencies {
     implementation 'com.android.support:cardview-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'
 
-    implementation 'com.azure.mobile:azuredata:0.1.0'
+    implementation 'com.azure.android:azuredata:0.1.0'
 }

--- a/Example/AzureDataAndroidExample/app/src/main/java/com/azure/mobile/azuredataandroidexample/App.kt
+++ b/Example/AzureDataAndroidExample/app/src/main/java/com/azure/mobile/azuredataandroidexample/App.kt
@@ -1,7 +1,6 @@
 package com.azure.mobile.azuredataandroidexample
 
 import android.app.Application
-import android.content.Context
 import com.azure.data.AzureData
 import com.azure.data.model.PermissionMode
 
@@ -18,47 +17,5 @@ class App : Application() {
         // Need to fill in the accountName + master key here!!
         AzureData.configure(this, "", "", PermissionMode.All)
 
-        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
-            // Save the fact we crashed out.
-            getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
-                    .putBoolean(KEY_APP_CRASHED, true).apply()
-            // Chain default exception handler.
-            defaultHandler?.uncaughtException(thread, exception)
-        }
-
-        val bRestartAfterCrash = getSharedPreferences(TAG, Context.MODE_PRIVATE)
-                .getBoolean(KEY_APP_CRASHED, false)
-        if (bRestartAfterCrash) {
-            // Clear crash flag.
-            isRestartedFromCrash = true
-
-            getSharedPreferences(TAG, Context.MODE_PRIVATE).edit()
-                    .putBoolean(KEY_APP_CRASHED, false).apply()
-        }
-    }
-
-    companion object {
-
-        fun activityResumed() {
-            isActivityVisible = true
-        }
-
-        fun activityPaused() {
-            isActivityVisible = false
-        }
-
-        var isActivityVisible: Boolean = false
-            private set
-
-        private val TAG = "AppDelegate"
-        private val KEY_APP_CRASHED = "KEY_APP_CRASHED"
-
-        var isRestartedFromCrash = false
-            private set
-
-        fun clearIsRestartedFromCrash() {
-            isRestartedFromCrash = false
-        }
     }
 }

--- a/Example/AzureDataAndroidExample/app/src/main/java/com/azure/mobile/azuredataandroidexample/fragment/ResourceListFragment.kt
+++ b/Example/AzureDataAndroidExample/app/src/main/java/com/azure/mobile/azuredataandroidexample/fragment/ResourceListFragment.kt
@@ -78,7 +78,7 @@ abstract class ResourceListFragment<TData: Resource> : RecyclerViewListFragment<
                     val items = response.resource?.items!!
 
                     activity?.runOnUiThread {
-                        typedAdapter.setItems(items.asList())
+                        typedAdapter.setItems(items)
                     }
                 }
                 else {

--- a/Example/AzureDataAndroidExample/build.gradle
+++ b/Example/AzureDataAndroidExample/build.gradle
@@ -1,11 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.41'
+
+    ext.kotlin_version = '1.2.71'
+
     repositories {
         google()
         jcenter()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -19,9 +22,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://dl.bintray.com/naterickard/Azure.Mobile/'
-        }
     }
 }
 

--- a/Example/AzureDataAndroidExample_Java/app/build.gradle
+++ b/Example/AzureDataAndroidExample_Java/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.azure.mobile.azuredataandroidexample_java"
@@ -37,8 +37,8 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation 'com.android.support:cardview-v7:27.1.1'
 
-    implementation 'com.azure.mobile:azuredata:0.1.0'
+    implementation 'com.azure.android:azuredata:0.1.0'
 
-    androidTestImplementation 'com.android.support:support-annotations:27.1.1'
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/CollectionsActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/CollectionsActivity.java
@@ -150,21 +150,4 @@ public class CollectionsActivity extends Activity {
                     }).show();
         });
     }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        if (_adapter != null) {
-            _adapter.clear();
-        }
-
-        App.activityResumed();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        App.activityPaused();
-    }
 }

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/CollectionsActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/CollectionsActivity.java
@@ -100,7 +100,7 @@ public class CollectionsActivity extends Activity {
             {
                 final ProgressDialog dialog = ProgressDialog.show(CollectionsActivity.this, "", "Loading. Please wait...", true);
 
-                AzureData.getCollections(_databaseId, onCallback(response -> {
+                AzureData.getCollections(_databaseId, null, onCallback(response -> {
 
                     Log.e(TAG, "Collection list result: " + response.isSuccessful());
 

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DatabaseActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DatabaseActivity.java
@@ -103,7 +103,7 @@ public class DatabaseActivity extends Activity {
             {
                 final ProgressDialog dialog = ProgressDialog.show(DatabaseActivity.this, "", "Loading. Please wait...", true);
 
-                AzureData.getDatabases(onCallback(response -> {
+                AzureData.getDatabases(null, onCallback(response -> {
 
                     Log.e(TAG, "Database list result: " + response.isSuccessful());
 

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DatabaseActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DatabaseActivity.java
@@ -123,21 +123,4 @@ public class DatabaseActivity extends Activity {
             }
         });
     }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        if (_adapter != null) {
-            _adapter.clear();
-        }
-
-        App.activityResumed();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        App.activityPaused();
-    }
 }

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DocumentsActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DocumentsActivity.java
@@ -119,16 +119,4 @@ public class DocumentsActivity extends Activity {
             }
         });
     }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        App.activityResumed();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        App.activityPaused();
-    }
 }

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DocumentsActivity.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Activities/DocumentsActivity.java
@@ -97,7 +97,7 @@ public class DocumentsActivity extends Activity {
             {
                 final ProgressDialog dialog = ProgressDialog.show(DocumentsActivity.this, "", "Loading. Please wait...", true);
 
-                AzureData.getDocuments(_collectionId, _databaseId, DictionaryDocument.class, onCallback(response -> {
+                AzureData.getDocuments(_collectionId, _databaseId, DictionaryDocument.class, null, onCallback(response -> {
 
                     Log.e(TAG, "Document list result: " + response.isSuccessful());
 

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Controllers/App.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Controllers/App.java
@@ -1,53 +1,11 @@
 package com.azure.mobile.azuredataandroidexample_java.Controllers;
 
 import android.app.Application;
-import android.content.Context;
-import android.content.pm.PackageInfo;
 
 import com.azure.data.AzureData;
 import com.azure.data.model.PermissionMode;
 
 public class App extends Application {
-
-    public static boolean isActivityVisible() {
-        return activityVisible;
-    }
-
-    public static void activityResumed() {
-        activityVisible = true;
-    }
-
-    public static void activityPaused() {
-        activityVisible = false;
-    }
-
-    private static boolean activityVisible;
-
-    private static Application sApplication;
-
-    private static final String TAG = "AppDelegate";
-    private static final String KEY_APP_CRASHED = "KEY_APP_CRASHED";
-    private static boolean isRestartedFromCrash = false;
-    public static boolean getIsRestartedFromCrash() { return isRestartedFromCrash; }
-    public static void clearIsRestartedFromCrash(){ isRestartedFromCrash = false; }
-
-    public static Application getApplication() {
-        return sApplication;
-    }
-
-    public static Context getContext() {
-        return getApplication().getApplicationContext();
-    }
-
-    public static String appVersion() {
-        try {
-            PackageInfo pInfo = sApplication.getPackageManager().getPackageInfo(sApplication.getPackageName(), 0);
-            return pInfo.versionName;
-        } catch(Exception e) {
-
-        }
-        return "1.6.4";
-    }
 
     @Override
     public void onCreate() {
@@ -55,32 +13,5 @@ public class App extends Application {
 
         // configure AzureData - fill in your account name and master key
         AzureData.configure(getApplicationContext(), "", "", PermissionMode.All);
-
-        sApplication = this;
-
-        final Thread.UncaughtExceptionHandler defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
-
-        Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
-
-            // Save the fact we crashed out.
-            getSharedPreferences( TAG , Context.MODE_PRIVATE ).edit()
-                    .putBoolean( KEY_APP_CRASHED, true ).apply();
-
-            // Chain default exception handler.
-            if ( defaultHandler != null ) {
-                defaultHandler.uncaughtException( thread, exception );
-            }
-        });
-
-        boolean bRestartAfterCrash = getSharedPreferences( TAG , Context.MODE_PRIVATE )
-                .getBoolean( KEY_APP_CRASHED, false );
-
-        if ( bRestartAfterCrash ) {
-            // Clear crash flag.
-            isRestartedFromCrash = true;
-
-            getSharedPreferences( TAG , Context.MODE_PRIVATE ).edit()
-                    .putBoolean( KEY_APP_CRASHED, false ).apply();
-        }
     }
 }

--- a/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Controllers/App.java
+++ b/Example/AzureDataAndroidExample_Java/app/src/main/java/com/azure/mobile/azuredataandroidexample_java/Controllers/App.java
@@ -5,6 +5,8 @@ import android.app.Application;
 import com.azure.data.AzureData;
 import com.azure.data.model.PermissionMode;
 
+import static com.azure.data.util.FunctionalUtils.onCallback;
+
 public class App extends Application {
 
     @Override
@@ -12,6 +14,8 @@ public class App extends Application {
         super.onCreate();
 
         // configure AzureData - fill in your account name and master key
-        AzureData.configure(getApplicationContext(), "", "", PermissionMode.All);
+        AzureData.configure(getApplicationContext(), "", "", PermissionMode.All, onCallback(builder -> {
+
+        }));
     }
 }

--- a/Example/AzureDataAndroidExample_Java/build.gradle
+++ b/Example/AzureDataAndroidExample_Java/build.gradle
@@ -1,10 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+
     repositories {
         jcenter()
         google()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         // NOTE: Do not place your application dependencies here; they belong
@@ -16,9 +18,6 @@ allprojects {
     repositories {
         jcenter()
         google()
-        maven {
-            url 'https://dl.bintray.com/naterickard/Azure.Mobile/'
-        }
     }
 }
 

--- a/azuredata/src/androidTest/java/com/azure/data/integration/DocumentTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/DocumentTest.kt
@@ -144,9 +144,11 @@ abstract class DocumentTest<TDoc : Document>(private val docType: Class<TDoc>)
         doc.setValue(customNumberKey, customNumberValue+1)
 
         var docResponse: Response<TDoc>? = null
+
         AzureData.createOrReplaceDocument(doc, collectionId, databaseId) {
             docResponse = it
         }
+        
         await().until { docResponse != null }
 
         assertResourceResponseSuccess(docResponse)

--- a/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/ResourceTest.kt
@@ -59,7 +59,6 @@ open class ResourceTest<TResource : Resource>(resourceType: ResourceType,
                     azureCosmosDbAccount,
                     azureCosmosPrimaryKey,
                     PermissionMode.All)
-
         }
 
         deleteResources()

--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -5,6 +5,8 @@ import com.azure.core.util.ContextProvider
 import com.azure.data.model.*
 import com.azure.data.model.indexing.IndexingPolicy
 import com.azure.data.service.*
+import com.azure.data.util.json.gsonBuilder
+import com.google.gson.GsonBuilder
 import okhttp3.HttpUrl
 import java.net.URL
 
@@ -19,67 +21,83 @@ class AzureData {
 
         internal var documentClient = DocumentClient.shared
 
+        //region Configuration
+
         private var configured = false
 
         @JvmStatic
-        fun configure(context: Context, accountName: String, masterKey: String, permissionMode: PermissionMode) {
+        fun configure(context: Context, accountName: String, masterKey: String, permissionMode: PermissionMode, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountName, masterKey, permissionMode)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
 
         @JvmStatic
-        fun configure(context: Context, accountUrl: URL, masterKey: String, permissionMode: PermissionMode) {
+        fun configure(context: Context, accountUrl: URL, masterKey: String, permissionMode: PermissionMode, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountUrl, masterKey, permissionMode)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
 
         @JvmStatic
-        fun configure(context: Context, accountUrl: HttpUrl, masterKey: String, permissionMode: PermissionMode) {
+        fun configure(context: Context, accountUrl: HttpUrl, masterKey: String, permissionMode: PermissionMode, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountUrl, masterKey, permissionMode)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
 
         @JvmStatic
-        fun configure(context: Context, accountName: String, permissionProvider: PermissionProvider) {
+        fun configure(context: Context, accountName: String, permissionProvider: PermissionProvider, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountName, permissionProvider)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
 
         @JvmStatic
-        fun configure(context: Context, accountUrl: URL, permissionProvider: PermissionProvider) {
+        fun configure(context: Context, accountUrl: URL, permissionProvider: PermissionProvider, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountUrl, permissionProvider)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
 
         @JvmStatic
-        fun configure(context: Context, accountUrl: HttpUrl, permissionProvider: PermissionProvider) {
+        fun configure(context: Context, accountUrl: HttpUrl, permissionProvider: PermissionProvider, configureGsonBuilder: (GsonBuilder) -> Unit = {}) {
 
             ContextProvider.init(context.applicationContext)
 
             documentClient.configure(accountUrl, permissionProvider)
 
             configured = true
+
+            configureGsonBuilder(gsonBuilder)
         }
+
+        //endregion
 
         @JvmStatic
         val isConfigured: Boolean

--- a/azuredata/src/main/java/com/azure/data/model/Query.kt
+++ b/azuredata/src/main/java/com/azure/data/model/Query.kt
@@ -14,7 +14,7 @@ class Query(properties: ArrayList<String>? = null) {
     private var orderByCalled = false
 
     private var selectProperties: ArrayList<String> = ArrayList()
-    private var fromFragment: String? = null
+//    private var fromFragment: String? = null
     private var whereFragment: String? = null
     private var andFragments: ArrayList<String> = ArrayList()
     private var orderByFragment: String? = null
@@ -169,13 +169,13 @@ class Query(properties: ArrayList<String>? = null) {
             return Query()
         }
 
-        fun select(vararg strings: String) : Query {
-            //        assert(selectCalled, "you can only call `select` once")
-            //        selectCalled = true;
-
-            //        self.selectProperties = properties
-
-            return Query()
-        }
+//        fun select(vararg strings: String) : Query {
+//            //        assert(selectCalled, "you can only call `select` once")
+//            //        selectCalled = true;
+//
+//            //        self.selectProperties = properties
+//
+//            return Query()
+//        }
     }
 }

--- a/azuredata/src/main/java/com/azure/data/util/ResourceOracle.kt
+++ b/azuredata/src/main/java/com/azure/data/util/ResourceOracle.kt
@@ -69,8 +69,8 @@ internal class ResourceOracle private constructor (appContext: Context, host: St
 
     private fun doStoreLinks(selfLink: String?, altLink: String?) {
 
-        selfLink?.let { selfLink ->
-            altLink?.let { altLink ->
+        selfLink?.let {
+            altLink?.let { _ ->
 
                 val altLinkSubstrings = altLink.split(slashCharacter)
                 val selfLinkSubstrings = selfLink.trimEnd('/').split(slashCharacter)

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -13,15 +13,15 @@ import java.util.*
  * Licensed under the MIT License.
 */
 
-val gson: Gson =
-        GsonBuilder()
-                .disableHtmlEscaping()
-                .checkVerboseMode()
-                .registerTypeAdapter(Date::class.java, DateTypeAdapter())
-                .registerTypeAdapter(Timestamp::class.java, TimestampAdapter())
-                .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
-                .registerTypeAdapter(ResourceWriteOperation::class.java, ResourceWriteOperationAdapter())
-                .create()
+internal val gsonBuilder = GsonBuilder()
+        .disableHtmlEscaping()
+        .checkVerboseMode()
+        .registerTypeAdapter(Date::class.java, DateTypeAdapter())
+        .registerTypeAdapter(Timestamp::class.java, TimestampAdapter())
+        .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
+        .registerTypeAdapter(ResourceWriteOperation::class.java, ResourceWriteOperationAdapter())!!
+
+val gson: Gson = gsonBuilder.create()
 
 fun GsonBuilder.checkVerboseMode() : GsonBuilder {
 

--- a/azuredata/src/main/java/com/azure/data/util/json/ResourceListDeserializer.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/ResourceListDeserializer.kt
@@ -8,7 +8,7 @@ internal class ResourceListJsonDeserializer<T: Resource> {
 
     fun deserialize(json: String, resourceType: Type): ResourceList<T> {
         val resourceList = ResourceList<T>()
-        var jsonObject = JsonParser().parse(json).asJsonObject
+        val jsonObject = JsonParser().parse(json).asJsonObject
 
         jsonObject.keySet().forEach {
             when (it) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
-include ':app', ':azurecore', ':azureauth', ':azuredata', ':azurepush', ':azurestorage', ':azuremobile'
+include ':azurecore', ':azureauth', ':azuredata', ':azurepush', ':azurestorage', ':azuremobile', ':example_kotlin', ':example_java'
+project(':example_kotlin').projectDir = new File('Example/AzureDataAndroidExample/app')
+project(':example_java').projectDir = new File('Example/AzureDataAndroidExample_Java/app')


### PR DESCRIPTION
Fixes #64

Changes Proposed in this pull request:
- Provide optional callback within .configure() method that allows you to alter the GsonBuilder used (add type adapters, etc.)
- Example apps added in as modules in the project and updated to compile correctly with JCenter packages
