### PR TITLE
Fixed custom gson type adapter not registering properly

### DIFF
--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -9,6 +9,7 @@ import com.azure.data.util.json.gsonBuilder
 import com.google.gson.GsonBuilder
 import okhttp3.HttpUrl
 import java.net.URL
+import com.azure.data.util.json.gson
 
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -35,6 +36,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         @JvmStatic
@@ -47,6 +50,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         @JvmStatic
@@ -59,6 +64,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         @JvmStatic
@@ -71,6 +78,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         @JvmStatic
@@ -83,6 +92,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         @JvmStatic
@@ -95,6 +106,8 @@ class AzureData {
             configured = true
 
             configureGsonBuilder(gsonBuilder)
+
+            gson = gsonBuilder.create()
         }
 
         //endregion

--- a/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
+++ b/azuredata/src/main/java/com/azure/data/util/json/GsonConfig.kt
@@ -21,7 +21,7 @@ internal val gsonBuilder = GsonBuilder()
         .registerTypeAdapter(DictionaryDocument::class.java, DocumentAdapter())
         .registerTypeAdapter(ResourceWriteOperation::class.java, ResourceWriteOperationAdapter())!!
 
-val gson: Gson = gsonBuilder.create()
+var gson: Gson = gsonBuilder.create()
 
 fun GsonBuilder.checkVerboseMode() : GsonBuilder {
 


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Fixes # .

Changes Proposed in this pull request:
- custom typeadapter passed on AzureData.configure() didn't work, because gson never got rebuilt with new typeadapter
