### PR TITLE
partition key ranges + invalid cross partition Query

### DIFF
--- a/azuredata/src/androidTest/java/com/azure/data/integration/DocumentCollectionPartitionedTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/DocumentCollectionPartitionedTests.kt
@@ -6,6 +6,8 @@ import com.azure.data.constants.HttpHeaderValue
 import com.azure.data.integration.common.ResourceTest
 import com.azure.data.model.*
 import com.azure.data.model.indexing.*
+import com.azure.data.model.partition.PartitionKeyRange
+import com.azure.data.service.ListResponse
 import org.awaitility.Awaitility.await
 import org.junit.Assert.*
 import org.junit.Test
@@ -315,5 +317,24 @@ class DocumentCollectionPartitionedTests : ResourceTest<DocumentCollection>(Reso
                 }
             }
         }
+    }
+
+    @Test
+    fun testGetCollectionPartitionKeyRanges() {
+
+        ensureCollection()
+
+        var response: ListResponse<PartitionKeyRange>? = null
+
+        AzureData.getCollectionPartitionKeyRanges(collectionId, databaseId) {
+            response = it
+        }
+
+        await().until {
+            response != null
+        }
+
+        assertListResponseSuccess(response)
+        assertTrue(response?.resource?.count!! > 0)
     }
 }

--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.azure.core.util.ContextProvider
 import com.azure.data.model.*
 import com.azure.data.model.indexing.IndexingPolicy
+import com.azure.data.model.partition.PartitionKeyRange
 import com.azure.data.service.*
 import com.azure.data.util.json.gsonBuilder
 import com.google.gson.GsonBuilder
@@ -218,6 +219,11 @@ class AzureData {
         @JvmStatic
         fun replaceCollection(collection: DocumentCollection, databaseId: String, indexingPolicy: IndexingPolicy, callback: (Response<DocumentCollection>) -> Unit) =
                 documentClient.replaceCollection(collection, databaseId, indexingPolicy, callback)
+
+        // list partition key ranges
+        @JvmStatic
+        fun getCollectionPartitionKeyRanges(collectionId: String, databaseId: String, callback: (ListResponse<PartitionKeyRange>) -> Unit) =
+                documentClient.getCollectionPartitionKeyRanges(collectionId, databaseId, callback)
 
         //endregion
 

--- a/azuredata/src/main/java/com/azure/data/model/DataError.kt
+++ b/azuredata/src/main/java/com/azure/data/model/DataError.kt
@@ -1,5 +1,7 @@
 package com.azure.data.model
 
+import com.azure.core.http.HttpStatusCode
+
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -19,6 +21,9 @@ class DataError(message: String?, val code: String? = null) : Error(message) {
             "Error: ${if (code != null) "\n\tCode: $code" else ""} \n\tMessage: $message"
 
     fun isConnectivityError(): Boolean = this.message.equals(DocumentClientError.InternetConnectivityError.message)
+
+    fun isInvalidCrossPartitionQueryError(): Boolean = this.code == HttpStatusCode.BadRequest.name &&
+            this.message?.startsWith(DocumentClientError.InvalidCrossPartitionQueryError.message!!) ?: false
 }
 
 // intermediary class used to deserialize DataErrors

--- a/azuredata/src/main/java/com/azure/data/model/DocumentClientError.kt
+++ b/azuredata/src/main/java/com/azure/data/model/DocumentClientError.kt
@@ -24,5 +24,6 @@ class DocumentClientError private constructor(msg: String) : Error(msg) {
         val Conflict = DocumentClientError("The request could not be completed due to a conflict.")
         val InternetConnectivityError = DocumentClientError("There is no internet connection to perform the request.")
         val InvalidThroughputError = DocumentClientError("Throughput must be between ${HttpHeaderValue.minDatabaseThroughput} and ${HttpHeaderValue.maxDatabaseThroughput} and be a multiple of ${HttpHeaderValue.databaseThroughputStep}")
+        val InvalidCrossPartitionQueryError = DocumentClientError("The provided cross partition query can not be directly served by the gateway")
     }
 }

--- a/azuredata/src/main/java/com/azure/data/model/ResourceList.kt
+++ b/azuredata/src/main/java/com/azure/data/model/ResourceList.kt
@@ -1,5 +1,6 @@
 package com.azure.data.model
 
+import com.azure.data.model.partition.PartitionKeyRange
 import com.google.gson.annotations.SerializedName
 
 /**
@@ -12,7 +13,7 @@ class ResourceList<T: Resource> : ResourceBase() {
     @SerializedName(Keys.countKey)
     var count: Int = 0
 
-    @SerializedName(Document.listName, alternate = [Database.listName, Attachment.listName, DocumentCollection.listName, Offer.listName, Permission.listName, StoredProcedure.listName, Trigger.listName, User.listName, UserDefinedFunction.listName])
+    @SerializedName(Document.listName, alternate = [Database.listName, Attachment.listName, DocumentCollection.listName, Offer.listName, Permission.listName, StoredProcedure.listName, Trigger.listName, User.listName, UserDefinedFunction.listName, PartitionKeyRange.listName])
     lateinit var items: List<T>
 
     val isPopulated: Boolean

--- a/azuredata/src/main/java/com/azure/data/model/ResourceLocation.kt
+++ b/azuredata/src/main/java/com/azure/data/model/ResourceLocation.kt
@@ -41,6 +41,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
     class Offer(id: String? = null) : ResourceLocation(ResourceType.Offer, id)
     class Resource(val resource: com.azure.data.model.Resource) : ResourceLocation(ResourceType.fromType(resource::class.java), resource.id)
     class Child(resourceType: ResourceType, val resource: com.azure.data.model.Resource, id: String? = null) : ResourceLocation(resourceType, id)
+    class PkRanges(val databaseId: String, collectionId: String? = null) : ResourceLocation(ResourceType.PkRanges, collectionId)
 
     fun path() : String = when (this) {
 
@@ -56,6 +57,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
         is Offer ->             "offers${id.path()}"
         is Resource ->          ResourceOracle.shared.getAltLink(resource)!!
         is Child ->             ResourceOracle.shared.getAltLink(resource) + "/${resourceType.path}${id.path()}"
+        is PkRanges ->          "dbs/$databaseId/colls${id.path()}/pkranges"
     }
 
     fun link() : String = when (this) {
@@ -72,6 +74,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
         is Offer ->             id?.toLowerCase() ?: ""
         is Resource ->          ResourceOracle.shared.getAltLink(resource)!!
         is Child ->             ResourceOracle.shared.getAltLink(resource) + id.pathIn("/${resourceType.path}")
+        is PkRanges ->          "dbs/$databaseId${id.pathIn("/colls")}"
     }
 
     fun type() : String = resourceType.path
@@ -100,6 +103,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
     fun altLink(id: String): String = if (path().lastPathComponent().equals(id, ignoreCase = true)) path() else "${path()}/$id"
 
     fun selfLink(resourceId: String): String? {
+
         directory()?.let {
             return "$it/$resourceId"
         }
@@ -135,6 +139,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
     }
 
     private fun directory(): String? {
+
         parentSelfLink()?.let {
             return when (this) {
                 is Database        -> it
@@ -149,6 +154,8 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
                 is Offer           -> it
                 is Child           -> "$it${this.resourceType.path}"
                 is Resource        -> ResourceOracle.shared.getSelfLink(this.resource)?.lastPathComponentRemoved()
+                is PkRanges        -> "${it}pkranges"
+                else               -> null
             }
         }
 
@@ -156,6 +163,7 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
     }
 
     private fun parentSelfLink(): String? {
+
         return when (this) {
             is Database        -> "dbs"
             is User            -> ResourceOracle.shared.getSelfLink(Database(this.databaseId))
@@ -169,6 +177,8 @@ sealed class ResourceLocation(val resourceType: ResourceType, val id: String? = 
             is Offer           -> "offers"
             is Child           -> ResourceOracle.shared.getSelfLink(this.resource)
             is Resource        -> ResourceOracle.shared.getSelfLink(this.resource)?.lastPathComponentRemoved()?.lastPathComponentRemoved()
+            is PkRanges        -> ResourceOracle.shared.getSelfLink(Collection(this.databaseId, this.id))
+            else               -> null
         }
     }
 }

--- a/azuredata/src/main/java/com/azure/data/model/ResourceType.kt
+++ b/azuredata/src/main/java/com/azure/data/model/ResourceType.kt
@@ -1,5 +1,6 @@
 package com.azure.data.model
 
+import com.azure.data.model.partition.PartitionKeyRange
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type
 
@@ -13,6 +14,7 @@ typealias UDF = UserDefinedFunction
 typealias Doc = Document
 typealias Atch = Attachment
 typealias Ofr = Offer
+typealias Pkr = PartitionKeyRange
 
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -30,7 +32,8 @@ enum class ResourceType(val path: String, fullname: String, val type: Type, val 
     Udf("udfs",                 UDF.resourceName,   object : TypeToken<UDF>() {}.type,      object : TypeToken<ResourceList<UDF>>() {}.type),
     Document("docs",            Doc.resourceName,   object : TypeToken<Doc>() {}.type,      object : TypeToken<ResourceList<Doc>>() {}.type),
     Attachment("attachments",   Atch.resourceName,  object : TypeToken<Atch>() {}.type,     object : TypeToken<ResourceList<Atch>>() {}.type),
-    Offer("offers",             Ofr.resourceName,   object : TypeToken<Ofr>() {}.type,      object : TypeToken<ResourceList<Ofr>>() {}.type);
+    Offer("offers",             Ofr.resourceName,   object : TypeToken<Ofr>() {}.type,      object : TypeToken<ResourceList<Ofr>>() {}.type),
+    PkRanges("pkranges",        Pkr.resourceName,   object : TypeToken<Pkr>() {}.type,      object : TypeToken<ResourceList<Pkr>>() {}.type);
 
     val listName: String = "${fullname}s"
 
@@ -47,6 +50,7 @@ enum class ResourceType(val path: String, fullname: String, val type: Type, val 
             Udf                 -> resourceType == Collection || resourceType == Database
             Permission          -> resourceType == User || resourceType == Database
             Attachment          -> resourceType == Document || resourceType == Collection || resourceType == Database
+            PkRanges            -> resourceType == Collection
         }
     }
 

--- a/azuredata/src/main/java/com/azure/data/model/partition/PartitionKeyRange.kt
+++ b/azuredata/src/main/java/com/azure/data/model/partition/PartitionKeyRange.kt
@@ -1,0 +1,23 @@
+package com.azure.data.model.partition
+
+import com.azure.data.model.Resource
+
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+class PartitionKeyRange : Resource() {
+
+    var minInclusive: String? = null
+
+    var maxExclusive: String? = null
+
+    var throughputFraction: Int? = null
+
+    companion object {
+
+        const val resourceName = "PartitionKeyRange"
+        const val listName = "PartitionKeyRanges"
+    }
+}


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Fixes #79 (partial).

Changes Proposed in this pull request:
- added support for getting partition key ranges on a collection
- fixed [a Query use case that requires pkRanges](https://stackoverflow.com/questions/50240232/cosmos-db-rest-api-order-by-with-partitioning)
- additional/improved tests for Query
