### PR TITLE
updated query tests + coroutine next() function

### DIFF
--- a/azuredata/build.gradle
+++ b/azuredata/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     androidTestImplementation "com.android.support.test:rules:$testRulesVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "org.awaitility:awaitility:$awaitilityVersion"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1"
 
     implementation project(':azurecore')
 }

--- a/azuredata/src/androidTest/java/com/azure/data/integration/QueryTests.kt
+++ b/azuredata/src/androidTest/java/com/azure/data/integration/QueryTests.kt
@@ -1,6 +1,7 @@
 package com.azure.data.integration
 
 import android.support.test.runner.AndroidJUnit4
+import com.azure.core.log.d
 import com.azure.data.AzureData
 import com.azure.data.findDocument
 import com.azure.data.integration.common.CustomDocument
@@ -8,9 +9,12 @@ import com.azure.data.integration.common.DocumentTest
 import com.azure.data.integration.common.PartitionedCustomDocment
 import com.azure.data.model.Query
 import com.azure.data.queryDocuments
+import com.azure.data.service.ListResponse
 import com.azure.data.service.next
+import kotlinx.coroutines.runBlocking
 import org.awaitility.Awaitility.await
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -268,8 +272,12 @@ class QueryTests : DocumentTest<PartitionedCustomDocment>(PartitionedCustomDocme
         createNewDocuments(12)
         val pageSize = 4
 
-        // Get the first one
-        AzureData.getDocuments(collectionId, databaseId, docType, pageSize) { resourceListResponse = it }
+        // Get the first page
+        queryDocuments(expectedDocs = pageSize, where = mapOf()) { _, query ->
+            collection?.queryDocuments(query, docType, pageSize) {
+                resourceListResponse = it
+            }
+        }
 
         await().until { resourceListResponse != null }
 
@@ -305,5 +313,108 @@ class QueryTests : DocumentTest<PartitionedCustomDocment>(PartitionedCustomDocme
         resourceListResponse!!.next {
             assertPageOnePastLast(it)
         }
+    }
+
+    @Test
+    fun queryDocumentsPagingLoopCoroutine() {
+
+        val idsFound = mutableListOf<String>()
+        val pageSize = 4
+        val totalDocs = 12
+
+        // let's create 12 docs and page them 4 at a time
+        createNewDocuments(totalDocs)
+
+        // Get the first page
+        queryDocuments(expectedDocs = pageSize, where = mapOf()) { _, query ->
+            collection?.queryDocuments(query, docType, pageSize) {
+                resourceListResponse = it
+            }
+        }
+
+        await().until { resourceListResponse != null }
+
+        assertPageN(idsFound, resourceListResponse, pageSize)
+
+        // get all the other pages
+        while (resourceListResponse!!.hasMoreResults) {
+
+            // runBlocking{} blocks the current thread until the response comes back
+            //  in practice, you'd likely not want to do this on the UI thread, but rather use coroutine/suspend function within your app code
+            resourceListResponse = runBlocking { resourceListResponse!!.next() }
+
+            if (resourceListResponse!!.hasMoreResults) {
+                assertPageN(idsFound, resourceListResponse, pageSize)
+            } else {
+                assertPageLast(idsFound, resourceListResponse, pageSize)
+            }
+        }
+
+        assertEquals("Expected 12 docs but only processed ${idsFound.size}", totalDocs, idsFound.size)
+
+        // Try to get one more - should fail
+        resourceListResponse!!.next {
+            assertPageOnePastLast(it)
+        }
+    }
+
+    @Test
+    fun queryDocumentsPagingRecursion() {
+
+        val idsFound = mutableListOf<String>()
+        val pageSize = 4
+        val totalDocs = 12
+
+        // let's create 12 docs and page them 4 at a time
+        createNewDocuments(totalDocs)
+
+        fun getDocs(response: ListResponse<PartitionedCustomDocment>? = null, callback: () -> Unit) {
+
+            response?.let {
+
+                d { "Getting another page of docs" }
+
+                if (response.hasMoreResults) {
+
+                    assertPageN(idsFound, response, pageSize)
+
+                    response.next {
+
+                        getDocs(it, callback)
+                    }
+                } else {
+
+                    assertPageLast(idsFound, response, pageSize)
+
+                    callback() // we're done, return to the caller
+                }
+            } ?: run {
+
+                // Get the first page
+                queryDocuments(expectedDocs = pageSize, where = mapOf()) { _, query ->
+
+                    collection?.queryDocuments(query, docType, pageSize) {
+
+                        resourceListResponse = it //set this to stop waiting in queryDocuments()
+
+                        if (it.hasMoreResults) {
+
+                            getDocs(it, callback)
+                        } else {
+                            fail("Query returned only 1 page")
+                        }
+                    }
+                }
+            }
+        }
+
+        var finished = false
+
+        // start the recursion to get all docs
+        getDocs { finished = true }
+
+        await().until { finished }
+
+        assertEquals("Expected 12 docs but only processed ${idsFound.size}", totalDocs, idsFound.size)
     }
 }

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -28,6 +28,8 @@ import java.net.URL
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 
 /**
@@ -969,6 +971,16 @@ class DocumentClient private constructor() {
             callback(ListResponse(DataError(ex)))
         }
     }
+
+    suspend fun <T : Resource> next(response : ListResponse<T>, resourceType: Type?): ListResponse<T> =
+
+        suspendCoroutine { cont ->
+
+            next(response, resourceType) {
+
+                cont.resume(it)
+            }
+        }
 
     // next
     fun <T : Resource> next(response : ListResponse<T>, resourceType: Type?, callback: (ListResponse<T>) -> Unit) {

--- a/azuredata/src/main/java/com/azure/data/service/Response.kt
+++ b/azuredata/src/main/java/com/azure/data/service/Response.kt
@@ -78,6 +78,9 @@ open class Response<T>(
 fun <T : Resource> ListResponse<T>.next(callback: (ListResponse<T>) -> Unit) =
         AzureData.documentClient.next(this, resourceType, callback)
 
+suspend fun <T : Resource> ListResponse<T>.next() =
+        AzureData.documentClient.next(this, resourceType)
+
 fun <T, U> Response<T>.map(transform: (T) -> U): Response<U> {
     return Response(request, response, jsonData, result.map(transform), resourceLocation, resourceType, fromCache)
 }


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Improves/clarifies #82 

Changes Proposed in this pull request:
- `suspend` fun next() added to ListResponse
- Fixed a query test to actually use a Query
- added 2 different tests for looping/paging Query results
