### PR TITLE
added overloads to pass partition key value to executeStoredProcedure…

### DIFF
--- a/azuredata/src/main/java/com/azure/data/AzureData.kt
+++ b/azuredata/src/main/java/com/azure/data/AzureData.kt
@@ -533,12 +533,22 @@ class AzureData {
         // execute
         @JvmStatic
         fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, collectionId: String, databaseId: String, callback: (DataResponse) -> Unit) =
-                documentClient.executeStoredProcedure(storedProcedureId, parameters, collectionId, databaseId, callback)
+                documentClient.executeStoredProcedure(storedProcedureId, parameters, null, collectionId, databaseId, callback)
+
+        // execute
+        @JvmStatic
+        fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, partitionKey: String, collectionId: String, databaseId: String, callback: (DataResponse) -> Unit) =
+                documentClient.executeStoredProcedure(storedProcedureId, parameters, partitionKey, collectionId, databaseId, callback)
 
         // execute
         @JvmStatic
         fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, collection: DocumentCollection, callback: (DataResponse) -> Unit) =
-                documentClient.executeStoredProcedure(storedProcedureId, parameters, collection, callback)
+                documentClient.executeStoredProcedure(storedProcedureId, parameters, null, collection, callback)
+
+        // execute
+        @JvmStatic
+        fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, partitionKey: String, collection: DocumentCollection, callback: (DataResponse) -> Unit) =
+                documentClient.executeStoredProcedure(storedProcedureId, parameters, partitionKey, collection, callback)
 
         //endregion
 

--- a/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
+++ b/azuredata/src/main/java/com/azure/data/service/DocumentClient.kt
@@ -516,15 +516,15 @@ class DocumentClient private constructor() {
     }
 
     // execute
-    fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, collectionId: String, databaseId: String, callback: (DataResponse) -> Unit) {
+    fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, partitionKey: String? = null, collectionId: String, databaseId: String, callback: (DataResponse) -> Unit) {
 
-        return execute(parameters, ResourceLocation.StoredProcedure(databaseId, collectionId, storedProcedureId), callback)
+        return execute(parameters, ResourceLocation.StoredProcedure(databaseId, collectionId, storedProcedureId), partitionKey, callback)
     }
 
     // execute
-    fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, collection: DocumentCollection, callback: (DataResponse) -> Unit) {
+    fun executeStoredProcedure(storedProcedureId: String, parameters: List<String>?, partitionKey: String? = null, collection: DocumentCollection, callback: (DataResponse) -> Unit) {
 
-        return execute(parameters, ResourceLocation.Child(ResourceType.StoredProcedure, collection, storedProcedureId), callback)
+        return execute(parameters, ResourceLocation.Child(ResourceType.StoredProcedure, collection, storedProcedureId), partitionKey, callback)
     }
 
     //endregion
@@ -1024,12 +1024,14 @@ class DocumentClient private constructor() {
     }
 
     // execute
-    private fun <T> execute(body: T? = null, resourceLocation: ResourceLocation, callback: (DataResponse) -> Unit) {
+    private fun <T> execute(body: T? = null, resourceLocation: ResourceLocation, partitionKey: String? = null, callback: (DataResponse) -> Unit) {
 
         try {
             val json = if (body != null) gson.toJson(body) else gson.toJson(arrayOf<String>())
 
-            createRequest(HttpMethod.Post, resourceLocation, jsonBody = json) {
+            val headers = setPartitionKeyHeader(partitionKey)
+
+            createRequest(HttpMethod.Post, resourceLocation, headers, json) {
 
                 sendRequest(it, resourceLocation, callback)
             }


### PR DESCRIPTION
…() and added a passing test

Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Fixes #94.

Changes Proposed in this pull request:
- added overloads to pass partition key value to executeStoredProcedure() (and core `execute()` method)
- added passing test